### PR TITLE
implement LLM fallback (Gemini → Mistral) with extended test coverage

### DIFF
--- a/backend/llm_provider.py
+++ b/backend/llm_provider.py
@@ -1,0 +1,104 @@
+import os
+
+from dotenv import load_dotenv
+from google import genai
+from mistralai import Mistral
+
+load_dotenv()
+
+GEMINI_MODEL = "gemini-2.5-flash"
+MISTRAL_MODEL = "mistral-small-latest"
+
+gemini_key = os.getenv("GEMINI_API_KEY")
+mistral_key = os.getenv("MISTRAL_API_KEY")
+
+if not gemini_key:
+    raise RuntimeError("GEMINI_API_KEY mangler i .env")
+
+if not mistral_key:
+    raise RuntimeError("MISTRAL_API_KEY mangler i .env")
+
+gemini_client = genai.Client(api_key=gemini_key)
+mistral_client = Mistral(api_key=mistral_key)
+
+
+def generate_with_gemini(prompt: str, force_fail: bool = False) -> str:
+    if force_fail:
+        raise RuntimeError("Simuleret Gemini LLM-fejl")
+
+    try:
+        response = gemini_client.models.generate_content(
+            model=GEMINI_MODEL,
+            contents=prompt,
+        )
+
+        if not response or not response.text:
+            raise RuntimeError("Tomt svar fra Gemini")
+
+        return response.text
+
+    except Exception as e:
+        print("Gemini fejlede:", type(e), repr(e))
+        raise
+
+
+def generate_with_mistral(prompt: str) -> str:
+    try:
+        response = mistral_client.chat.complete(
+            model=MISTRAL_MODEL,
+            messages=[
+                {
+                    "role": "user",
+                    "content": prompt,
+                }
+            ],
+        )
+
+        answer = response.choices[0].message.content
+
+        if not answer:
+            raise RuntimeError("Mistral returnerede tomt svar")
+
+        return answer
+
+    except Exception as e:
+        print("Mistral fejlede:", type(e), repr(e))
+        raise
+
+
+def generate_llm_response(prompt: str, force_fail: bool = False) -> dict:
+    print("Kalder LLM-wrapper")
+
+    try:
+        reply = generate_with_gemini(prompt, force_fail=force_fail)
+
+        return {
+            "reply": reply,
+            "provider": "gemini",
+            "fallback_used": False,
+        }
+
+    except Exception as gemini_error:
+        print("Gemini kunne ikke bruges. Prøver Mistral:", repr(gemini_error))
+
+        try:
+            reply = generate_with_mistral(prompt)
+
+            return {
+                "reply": reply,
+                "provider": "mistral",
+                "fallback_used": True,
+            }
+
+        except Exception as mistral_error:
+            print("Mistral kunne heller ikke bruges:", repr(mistral_error))
+
+            return {
+                "reply": (
+                    "Jeg kan desværre ikke generere et svar lige nu, "
+                    "fordi AI-tjenesten ikke svarer. Prøv igen om lidt."
+                ),
+                "provider": None,
+                "fallback_used": True,
+            }
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,13 +1,12 @@
-import os
-from typing import List
+from typing import List, Optional
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from google import genai
 from pydantic import BaseModel, Field
 
 from rag_pipeline import retrieve_top_chunks, build_context
+from llm_provider import generate_llm_response
 
 load_dotenv()
 
@@ -15,19 +14,11 @@ app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # kun til lokal udvikling
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-api_key = os.getenv("GEMINI_API_KEY")
-if not api_key:
-    raise RuntimeError("GEMINI_API_KEY mangler i .env")
-
-client = genai.Client(api_key=api_key)
-
-MODEL_NAME = "gemini-2.5-flash"
 
 
 class ChatMessage(BaseModel):
@@ -37,7 +28,11 @@ class ChatMessage(BaseModel):
 
 class Message(BaseModel):
     message: str
+    customer_id: Optional[int] = None
     history: List[ChatMessage] = Field(default_factory=list)
+
+    # Kun til test af fallback. Frontend behøver ikke sende den.
+    force_llm_fail: bool = False
 
 
 def classify_question(user_text: str) -> str:
@@ -48,7 +43,6 @@ def classify_question(user_text: str) -> str:
         "skal jeg",
         "hvad er bedst",
         "kan jeg få",
-
         "hvad passer bedst",
         "for mig",
         "min situation",
@@ -79,60 +73,24 @@ def classify_question(user_text: str) -> str:
     return "simple"
 
 
-def get_fallback_reply() -> str:
-    return (
-        "Det spørgsmål kræver en vurdering af din konkrete situation. "
-        "Jeg kan ikke give personlig rådgivning, men jeg kan godt forklare de generelle regler."
-    )
-
-def is_pension_related(user_text: str) -> bool:
+def needs_customer_data(user_text: str) -> bool:
     text = user_text.lower()
 
-    pension_keywords = [
-        "pension",
-        "ratepension",
-        "livrente",
-        "aldersopsparing",
-        "folkepension",
-        "atp",
-        "seniorpension",
-        "førtidspension",
-        "tidlig pension",
+    personal_keywords = [
+        "min pension",
+        "mit afkast",
+        "mine forsikringer",
+        "hvor meget har jeg",
+        "hvad har jeg stående",
+        "min opsparing",
+        "min risikoprofil",
+        "mine omkostninger",
         "pal-skat",
-        "pensionsafkastskat",
-        "skat ved pension",
-        "beskatning af pension",
-        "skattemæssige",
-        "indbetaling",
-        "udbetaling",
-        "begunstiget",
-        "begunstigelse",
-        "kritisk sygdom",
-        "forsikring",
-        "arbejdsevne",
-        "opsparing",
-        "modregning",
-        "skifte job",
-        "nyt job",
-        "sygdom",
-        "syg",
-        "blevet syg",
-        "jeg er blevet syg",
-        "hvad gør jeg",
-        "hvad skal jeg gøre",
-        "dødsfald",
+        "skattekode",
     ]
-    return any(keyword in text for keyword in pension_keywords)
 
-def clean_reply(reply: str) -> str:
-    return (
-        reply
-        .replace("*   ", "")
-        .replace("* ", "")
-        .replace("**", "")
-        .replace("#", "")
-        .strip()
-    )
+    return any(keyword in text for keyword in personal_keywords)
+
 
 SYSTEM_PROMPT = """
 Du er en AI-assistent i et bachelorprojekt om pensionsrådgivning.
@@ -146,23 +104,20 @@ Svar kort, tydeligt og på dansk.
 
 Du håndterer kun first-level spørgsmål, dvs. generelle og standardiserede spørgsmål om pension.
 Du må ikke give personlig økonomisk, juridisk eller skattemæssig rådgivning.
-Hvis et spørgsmål kræver personlig vurdering, skal du tage forbehold og anbefale kontakt til en rådgiver.
 
-Ved generelle definitionsspørgsmål, fx "hvad er ratepension?", skal du svare neutralt og ikke skrive "hos PenSam" eller "hos os".
+Hvis et spørgsmål kræver personlig vurdering:
+- giv et kort generelt svar
+- skriv tydeligt at det afhænger af brugerens situation
+- anbefal kontakt til rådgiver
 
-Hvis spørgsmålet handler om en konkret handling, service eller vejledning hos PenSam, fx at samle pension, ændre begunstigelse, finde overblik eller kontakte rådgiver, må du formulere svaret i en PenSam-kontekst.
-I den situation må du skrive som PenSam, fx "hos PenSam", "hos os", "vi kan hjælpe" og "kontakt os", men kun hvis det er i overensstemmelse med den givne kontekst.
+Ved definitionsspørgsmål:
+- svar neutralt
+- undgå "hos os" eller "PenSam"
 
-Hvis et spørgsmål kan forstås bredt, skal du starte med en generel forklaring og derefter præcisere relevante særlige tilfælde fra konteksten.
+Ved handlinger, fx sygdom, samle pension eller kontakt:
+- du må skrive "hos PenSam" og "kontakt os"
 
-Ved hvorfor-spørgsmål skal du starte med en direkte årsagsforklaring i første sætning, før du uddyber med regler eller eksempler.
-
-Hvis spørgsmålet er generelt, fx "kan jeg få pension udbetalt som engangsbeløb", skal du tydeligt afgrænse svaret og forklare, at det afhænger af typen af pension.
-Undgå at starte med "Ja", hvis svaret ikke gælder alle tilfælde.
-Brug ikke markdown-formattering. Skriv i almindelig tekst.
-Hvis konteksten indeholder centrale tal som satser, perioder eller grænser, må du gerne nævne dem kort i svaret.
-
-Du må aldrig bruge markdown. Brug ikke stjerner, punktopstillinger, fed skrift eller nummererede lister, medmindre brugeren specifikt beder om en liste.
+Skriv i almindelig tekst. Ingen markdown.
 """
 
 
@@ -178,12 +133,6 @@ def chat(msg: Message):
     if not user_text:
         raise HTTPException(status_code=400, detail="Beskeden er tom.")
 
-    if not is_pension_related(user_text):
-        return {
-            "reply": "Det spørgsmål ligger uden for mit område. Jeg kan kun hjælpe med generelle spørgsmål om pension.",
-            "sources": []
-    }
-
     try:
         print("User text:", user_text)
 
@@ -194,6 +143,22 @@ def chat(msg: Message):
         question_type = classify_question(user_text)
         print("Question type:", question_type)
 
+        if needs_customer_data(user_text):
+            if msg.customer_id is None:
+                return {
+                    "reply": "Du skal være logget ind for at få svar på spørgsmål om din egen pension.",
+                    "sources": [],
+                    "provider": None,
+                    "fallback_used": False,
+                }
+
+            return {
+                "reply": "Denne funktion er ikke implementeret endnu, men her vil dine personlige data blive brugt.",
+                "sources": [],
+                "provider": None,
+                "fallback_used": False,
+            }
+
         retrieval_query = f"""
 Tidligere samtale:
 {conversation_history}
@@ -202,56 +167,47 @@ Nyeste spørgsmål:
 {user_text}
 """
 
-        # Use fewer chunks for simple questions and more chunks for broader questions.
-        if question_type == "simple":
-            top_k = 3
-        elif question_type == "semi":
-            top_k = 3
-        else:
+        if question_type == "complex":
             top_k = 5
+        else:
+            top_k = 3
 
         top_chunks = retrieve_top_chunks(retrieval_query, top_k=top_k)
 
         if not top_chunks:
             return {
                 "reply": "Det fremgår ikke af mit datagrundlag.",
-                "sources": []
+                "sources": [],
+                "provider": None,
+                "fallback_used": False,
             }
 
         context = build_context(top_chunks)
 
-        print("----- RETRIEVED CONTEXT -----")
+        print("----- CONTEXT -----")
         print(context)
-        print("-----------------------------")
+        print("-------------------")
 
         if question_type == "complex":
             extra_instruction = """
-Spørgsmålet kræver en personlig vurdering.
-Du skal:
-- først give et kort generelt svar baseret på konteksten
-- derefter tydeligt skrive, at det afhænger af brugerens situation
-- anbefale kontakt til en rådgiver
-- undgå at give konkret personlig rådgivning
+Spørgsmålet kræver personlig vurdering.
+Giv:
+- kort generelt svar
+- sig at det afhænger af situation
+- anbefal rådgiver
 """
         elif question_type == "semi":
             extra_instruction = """
-Spørgsmålet handler om en handling eller situation.
-Du skal:
-- give et kort svar på hvad situationen betyder
-- hvis konteksten indeholder trin-for-trin handlinger, gengiv dem kort og konkret
-- inkludere ét kort forbehold
-- anbefale kontakt til en rådgiver, hvis spørgsmålet kræver personlig vurdering
-- undgå lange forklaringer
-- skriv i almindelig tekst uden markdown
+Spørgsmålet handler om en situation.
+Giv:
+- kort forklaring
+- evt. trin hvis i kontekst
+- ét forbehold
 """
         else:
             extra_instruction = """
-Spørgsmålet er et first-level spørgsmål.
-Du skal give et kort, klart og direkte svar.
-Brug ikke markdown, punktlister, stjerner eller overskrifter.
-Skriv i almindelig tekst.
-Hvis konteksten indeholder centrale tal som satser, perioder eller grænser, må du gerne nævne dem kort i svaret.
-- hvis konteksten indeholder trin-for-trin handlinger, skal du gengive dem kort og konkret
+Spørgsmålet er simpelt.
+Giv kort og direkte svar.
 """
 
         prompt = f"""
@@ -263,20 +219,17 @@ Ekstra instruktion:
 Kontekst:
 {context}
 
-
 Tidligere samtale:
 {conversation_history}
 
-Brugerens nyeste spørgsmål:
+Spørgsmål:
 {user_text}
 """
 
-        response = client.models.generate_content(
-            model=MODEL_NAME,
-            contents=prompt,
+        llm_result = generate_llm_response(
+            prompt,
+            force_fail=msg.force_llm_fail,
         )
-
-        reply = clean_reply(response.text) if response.text else "Jeg kunne ikke generere et svar."
 
         sources = [
             {
@@ -288,10 +241,12 @@ Brugerens nyeste spørgsmål:
         ]
 
         return {
-            "reply": reply,
+            "reply": llm_result["reply"],
             "sources": sources,
+            "provider": llm_result["provider"],
+            "fallback_used": llm_result["fallback_used"],
         }
 
     except Exception as e:
-        print("Fejl i RAG-flow:", repr(e))
-        raise HTTPException(status_code=500, detail=f"Fejl i RAG-flow: {str(e)}")
+        print("Fejl:", repr(e))
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/rag_test_cases/test_llm_fallback.py
+++ b/backend/rag_test_cases/test_llm_fallback.py
@@ -1,0 +1,229 @@
+# for at køre test skriv følgende i terminalen: python3 backend/rag_test_cases/test_llm_fallback.py (husk at have backend kørende)
+
+import requests
+
+URL = "http://127.0.0.1:8000/chat"
+
+
+def call_chat(
+    question: str,
+    force_llm_fail: bool = False,
+    customer_id=None,
+    history=None,
+) -> tuple[int, dict]:
+    payload = {
+        "message": question,
+        "history": history or [],
+        "force_llm_fail": force_llm_fail,
+    }
+
+    if customer_id is not None:
+        payload["customer_id"] = customer_id
+
+    response = requests.post(
+        URL,
+        json=payload,
+        timeout=120,
+    )
+
+    try:
+        data = response.json()
+    except Exception:
+        data = {"raw": response.text}
+
+    return response.status_code, data
+
+
+def assert_ok_response(data: dict) -> None:
+    assert "reply" in data
+    assert "sources" in data
+    assert "provider" in data
+    assert "fallback_used" in data
+    assert data["reply"]
+
+
+def test_normal_gemini() -> None:
+    print("\nTEST 1: Normal Gemini-kald")
+
+    status, data = call_chat("Hvad er ratepension?")
+
+    print(data)
+
+    assert status == 200
+    assert_ok_response(data)
+    assert data["provider"] == "gemini"
+    assert data["fallback_used"] is False
+    assert len(data["sources"]) > 0
+
+    print("TEST 1 bestået")
+
+
+def test_mistral_fallback() -> None:
+    print("\nTEST 2: Mistral fallback")
+
+    status, data = call_chat(
+        question="Hvad er ratepension?",
+        force_llm_fail=True,
+    )
+
+    print(data)
+
+    assert status == 200
+    assert_ok_response(data)
+    assert data["provider"] == "mistral"
+    assert data["fallback_used"] is True
+    assert len(data["sources"]) > 0
+
+    print("TEST 2 bestået")
+
+
+def test_empty_message() -> None:
+    print("\nTEST 3: Tom besked")
+
+    status, data = call_chat("")
+
+    print(data)
+
+    assert status == 400
+    assert "detail" in data
+
+    print("TEST 3 bestået")
+
+
+def test_out_of_scope_question() -> None:
+    print("\nTEST 4: Out-of-scope spørgsmål")
+
+    status, data = call_chat("Hvad er moms?")
+
+    print(data)
+
+    assert status == 200
+    assert "reply" in data
+    assert data["reply"]
+    assert "datagrundlag" in data["reply"].lower() or data["sources"] == []
+
+    print("TEST 4 bestået")
+
+
+def test_customer_question_without_login() -> None:
+    print("\nTEST 5: Kundespecifikt spørgsmål uden login")
+
+    status, data = call_chat("Hvor meget har jeg stående på min pension?")
+
+    print(data)
+
+    assert status == 200
+    assert "reply" in data
+    assert "logget ind" in data["reply"].lower()
+    assert data["provider"] is None
+
+    print("TEST 5 bestået")
+
+
+def test_customer_question_with_customer_id() -> None:
+    print("\nTEST 6: Kundespecifikt spørgsmål med customer_id")
+
+    status, data = call_chat(
+        question="Hvor meget har jeg stående på min pension?",
+        customer_id=1,
+    )
+
+    print(data)
+
+    assert status == 200
+    assert "reply" in data
+    assert "ikke implementeret" in data["reply"].lower() or "personlige data" in data["reply"].lower()
+
+    print("TEST 6 bestået")
+
+
+def test_with_history() -> None:
+    print("\nTEST 7: Samtalehistorik")
+
+    history = [
+        {
+            "role": "user",
+            "content": "Hvad er ratepension?",
+        },
+        {
+            "role": "assistant",
+            "content": "Ratepension udbetales over en begrænset periode.",
+        },
+    ]
+
+    status, data = call_chat(
+        question="Og hvad er forskellen på livrente?",
+        history=history,
+    )
+
+    print(data)
+
+    assert status == 200
+    assert_ok_response(data)
+    assert data["provider"] in ["gemini", "mistral"]
+
+    print("TEST 7 bestået")
+
+
+def test_long_question() -> None:
+    print("\nTEST 8: Langt spørgsmål")
+
+    question = (
+        "Jeg prøver at forstå pension bedre, fordi jeg har hørt om ratepension, "
+        "livrente og aldersopsparing, men jeg er lidt forvirret over forskellen. "
+        "Kan du forklare forskellen på de tre pensionstyper på en simpel måde?"
+    )
+
+    status, data = call_chat(question)
+
+    print(data)
+
+    assert status == 200
+    assert_ok_response(data)
+    assert len(data["reply"]) > 50
+
+    print("TEST 8 bestået")
+
+
+def test_multiple_requests() -> None:
+    print("\nTEST 9: Flere kald i træk")
+
+    questions = [
+        "Hvad er ratepension?",
+        "Hvad er livrente?",
+        "Hvad er aldersopsparing?",
+    ]
+
+    for question in questions:
+        status, data = call_chat(question)
+
+        print(question)
+        print(data)
+
+        assert status == 200
+        assert_ok_response(data)
+        assert data["provider"] == "gemini"
+        assert data["fallback_used"] is False
+
+    print("TEST 9 bestået")
+
+
+def main() -> None:
+    print("\nKører udvidet LLM fallback- og grænsetest...")
+    print("Backend skal køre på http://127.0.0.1:8000")
+
+    test_normal_gemini()
+    test_mistral_fallback()
+    test_empty_message()
+    test_out_of_scope_question()
+    test_customer_question_without_login()
+    test_customer_question_with_customer_id()
+    test_with_history()
+    test_long_question()
+    test_multiple_requests()
+
+    print("\nAlle tests gennemført korrekt.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Feature: LLM Fallback + Extended Testing

Denne PR introducerer en fallback-mekanisme for LLM-kald samt en udvidet test-suite for backendens robusthed.

---

## Hvad er implementeret

### 1. LLM Fallback (Gemini → Mistral)
- Primær model: Gemini
- Fallback model: Mistral
- Automatisk fallback ved:
  - API fejl
  - rate limits
  - tomt svar
- Returnerer metadata:
  - `provider`
  - `fallback_used`

---

### 2. LLM Wrapper
- Ny fil: `llm_provider.py`
- Centraliserer LLM-kald
- Håndterer:
  - fejl
  - fallback
  - logging

---

### 3. Testbar fallback (force_fail)
- Tilføjet `force_llm_fail` parameter i `/chat`
- Bruges kun til test
- Gør det muligt at simulere fejl uden at ændre `.env`

---

### 4. Udvidet test-suite

Ny testfil:
backend/rag_test_cases/test_llm_fallback.py


Dækker:

- Normal Gemini-kald
- Mistral fallback
- Tom input (400)
- Out-of-scope spørgsmål
- Kundespecifik routing (med/uden login)
- Samtalehistorik
- Lange spørgsmål
- Flere kald i træk

---

## Designovervejelser

- Fallback er isoleret i ét lag (LLM wrapper)
- Backend er stadig RAG-first (LLM bruges kun på kontekst)
- Systemet er nu mere robust mod:
  - API nedbrud
  - rate limiting
  - uforudsete fejl

---

## Kendte begrænsninger

- Out-of-scope spørgsmål kan stadig hente irrelevante chunks (retrieval støj)
- LLM afviser dog korrekt via prompt:  
  _"Det fremgår ikke af mit datagrundlag."_

---

## Sådan testes det

Start backend:

```bash
uvicorn main:app --reload

Kør tests:
python3 backend/rag_test_cases/test_llm_fallback.py

OBS: efterspørg om nøgle (Sabrina)